### PR TITLE
Added support for pyinstaller3 (pyi-build is DEPRECATE)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -7,7 +7,7 @@
 # See accompanying LICENSE.txt file or at http://opensource.org/licenses/MIT
 #
 
-BUILD="pyi-build"
+BUILD="pyinstaller"
 
 #export LANG=en
 set -e

--- a/misc/Remote-Support-Tool.spec
+++ b/misc/Remote-Support-Tool.spec
@@ -54,7 +54,7 @@ ARCH_DIR = os.path.join(SRC_DIR, 'arch', ARCH)
 # Start Analysis to find the files the program needs.
 #
 
-a = Analysis([os.path.join('src', 'Support.py')],
+a = Analysis([os.path.join('../src', 'Support.py')],
              pathex=[BASE_DIR,],
              hiddenimports=[],
              excludes=EXCLUCES,


### PR DESCRIPTION
As described here pyi-build is deprecate since versione 3 of pyinstaller:
https://github.com/pyinstaller/pyinstaller/commit/a5cd4b748d5bd831ff1869bcf55133b125f156eb
https://github.com/pyinstaller/pyinstaller/issues/1490